### PR TITLE
Add fullscreen support for non-Webkit browsers.

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -174,7 +174,13 @@ void main( void ) {
 				fullscreenButton.textContent = 'fullscreen';
 				fullscreenButton.addEventListener( 'click', function ( event ) {
 
-					document.body.webkitRequestFullScreen( Element.ALLOW_KEYBOARD_INPUT );
+					if (document.body.requestFullScreen) {
+						document.body.requestFullScreen();
+					} else if (document.body.mozRequestFullScreen) {
+						document.body.mozRequestFullScreen();
+					} else if (document.body.webkitRequestFullScreen) {
+						document.body.webkitRequestFullScreen( Element.ALLOW_KEYBOARD_INPUT );
+					}
 
 				}, false );
 


### PR DESCRIPTION
Gecko supports the prefixed fullscreen API in 9+ (pref'ed off in 9).
