### PR TITLE
index.html: swap precision and #extension directives.

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -63,9 +63,9 @@
 		<script src="js/codemirror.js"></script>
 		<script src="js/glsl.js"></script>
 
-		<script id="example" type="x-shader/x-fragment">precision mediump float;
+		<script id="example" type="x-shader/x-fragment">#extension GL_OES_standard_derivatives : enable
 
-#extension GL_OES_standard_derivatives : enable
+precision mediump float;
 
 uniform float time;
 uniform vec2 mouse;


### PR DESCRIPTION
According to WebGL 1.0:
https://www.khronos.org/registry/webgl/specs/latest/1.0/#4.3
"A WebGL implementation must only accept shaders which conform to The
OpenGL ES Shading Language, Version 1.00"

Accorting to OpenGL ES Shading Language 1.00 Specification:
https://www.khronos.org/registry/OpenGL/specs/es/2.0/GLSL_ES_Specification_1.00.pdf
Section 3.4 Preprocessor:

"Each extension can define its allowed granularity of scope. If nothing
 is said, the granularity is a single compilation unit, and the
extension directives must occur before any non-preprocessor tokens."

Since precision is a non-preprocessor token, #extension should be placed
before. Some very pedantic drivers are rejecting this construct.

Signed-off-by: Julien Olivain <ju.o@free.fr>