### PR TITLE
server: add read only mode

### DIFF
--- a/server/assets/gallery.html
+++ b/server/assets/gallery.html
@@ -123,7 +123,13 @@ gallery by <a href="https://twitter.com/thevaw">@thevaw</a>, <a href="https://tw
 <a href="https://twitter.com/mrdoob">@mrdoob</a><br/>
 editor by <a href="https://twitter.com/mrdoob">@mrdoob</a>, <a href="https://twitter.com/mrkishi">@mrkishi</a>, <a href="https://twitter.com/p01">@p01</a>, <a href="https://twitter.com/alteredq">@alteredq</a>, <a href="https://twitter.com/kusmabite">@kusmabite</a> and <a href="https://twitter.com/emackey">@emackey</a>
 <br/><br/>
+
+{{ if .ReadOnly }}
+<h2 style="color:#ff6961">The server is in maintenance mode. You can not create or modify effects.</h2>
+{{ else }}
 <a href="/e"><button>new shader</button></a>
+{{ end }}
+
 <div id="gallery">
 
 {{ if .Admin }}

--- a/server/cmd/glslsandbox/main.go
+++ b/server/cmd/glslsandbox/main.go
@@ -25,6 +25,7 @@ type Config struct {
 	TLSAddr    string `envconfig:"TLS_ADDR"`
 	Domains    string `envconfig:"DOMAINS" default:"www.glslsandbox.com,glslsandbox.com"`
 	Dev        bool   `envconfig:"DEV" default:"true"`
+	ReadOnly   bool   `envconfig:"READ_ONLY" default:"false"`
 }
 
 func main() {
@@ -82,6 +83,7 @@ func start() error {
 		auth,
 		cfg.DataPath,
 		cfg.Dev,
+		cfg.ReadOnly,
 	)
 	if err != nil {
 		return fmt.Errorf("could not create server: %w", err)


### PR DESCRIPTION
In read only mode the endpoint to save new effects or add new versions is deactivated. Also in the gallery the create button is deactivated and there is a notice that says:

    The server is in maintenance mode. You can not create or modify effects.

![read_only](https://github.com/mrdoob/glsl-sandbox/assets/1829/375a59dd-508e-416d-8e30-e438c0dbf7cc)

The button to save effects in the editor is not deactivated as it will take a bit more time and wanted to have the page up as soon as possible.

Hopefully I've cleaned up the spam in the database and the configuration is set in the server to startup in read only mode. Merging and creating a new version should do the trick.